### PR TITLE
refactor: modularize frontend script

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -144,62 +144,6 @@ formats:
     </footer>
   </div>
 
-  <script src="app.js"></script>
-  <script>
-    // Autoajuste de <textarea> sin sacar "Upload JSON" de la ventana
-    (function () {
-      const ta = document.getElementById('text');
-      const left = document.querySelector('.left');
-      const footer = document.querySelector('.site-footer');
-      if (!ta || !left) return;
-
-      const MIN_H = 150;
-      const VH_CAP = 0.8;
-      const BELOW_PAD = 24;
-
-      function getUploadBlock() {
-        const blocks = left.querySelectorAll('.section-block');
-        return blocks[blocks.length - 1] || null;
-      }
-
-      function maxAllowedHeight() {
-        const vpH = window.innerHeight;
-        const footerH = footer?.offsetHeight || 0;
-        const taRect = ta.getBoundingClientRect();
-        const upload = getUploadBlock();
-        const uploadH = upload ? upload.getBoundingClientRect().height : 0;
-
-        const visibleBelow = vpH - taRect.top - footerH - BELOW_PAD;
-        const reserveForUpload = uploadH + BELOW_PAD;
-        const viewportCap = Math.floor(vpH * VH_CAP);
-
-        return Math.max(MIN_H, Math.min(visibleBelow - reserveForUpload, viewportCap));
-      }
-
-      function autoresize() {
-        ta.style.height = 'auto';
-        const cap = maxAllowedHeight();
-        const desired = Math.max(MIN_H, Math.min(ta.scrollHeight, cap));
-        ta.style.height = desired + 'px';
-        ta.style.overflowY = (ta.scrollHeight > desired) ? 'auto' : 'hidden';
-      }
-
-      ['input', 'change'].forEach(evt => ta.addEventListener(evt, autoresize));
-      ta.addEventListener('paste', () => setTimeout(autoresize, 0));
-      window.addEventListener('resize', autoresize);
-      document.addEventListener('DOMContentLoaded', autoresize);
-
-      const clearBtn = document.getElementById('clear');
-      if (clearBtn) {
-        clearBtn.addEventListener('click', () => {
-          ta.value = '';
-          ta.style.height = MIN_H + 'px';
-          ta.style.overflowY = 'hidden';
-        });
-      }
-
-      autoresize();
-    })();
-  </script>
+  <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/public/js/autoResize.js
+++ b/public/js/autoResize.js
@@ -1,0 +1,53 @@
+export function initAutoResize(){
+  const ta = document.getElementById('text');
+  const left = document.querySelector('.left');
+  const footer = document.querySelector('.site-footer');
+  if(!ta || !left) return;
+
+  const MIN_H = 150;
+  const VH_CAP = 0.8;
+  const BELOW_PAD = 24;
+
+  function getUploadBlock(){
+    const blocks = left.querySelectorAll('.section-block');
+    return blocks[blocks.length - 1] || null;
+  }
+
+  function maxAllowedHeight(){
+    const vpH = window.innerHeight;
+    const footerH = footer?.offsetHeight || 0;
+    const taRect = ta.getBoundingClientRect();
+    const upload = getUploadBlock();
+    const uploadH = upload ? upload.getBoundingClientRect().height : 0;
+
+    const visibleBelow = vpH - taRect.top - footerH - BELOW_PAD;
+    const reserveForUpload = uploadH + BELOW_PAD;
+    const viewportCap = Math.floor(vpH * VH_CAP);
+
+    return Math.max(MIN_H, Math.min(visibleBelow - reserveForUpload, viewportCap));
+  }
+
+  function autoresize(){
+    ta.style.height = 'auto';
+    const cap = maxAllowedHeight();
+    const desired = Math.max(MIN_H, Math.min(ta.scrollHeight, cap));
+    ta.style.height = desired + 'px';
+    ta.style.overflowY = (ta.scrollHeight > desired) ? 'auto' : 'hidden';
+  }
+
+  ['input', 'change'].forEach(evt => ta.addEventListener(evt, autoresize));
+  ta.addEventListener('paste', () => setTimeout(autoresize, 0));
+  window.addEventListener('resize', autoresize);
+  document.addEventListener('DOMContentLoaded', autoresize);
+
+  const clearBtn = document.getElementById('clear');
+  if(clearBtn){
+    clearBtn.addEventListener('click', () => {
+      ta.value = '';
+      ta.style.height = MIN_H + 'px';
+      ta.style.overflowY = 'hidden';
+    });
+  }
+
+  autoresize();
+}

--- a/public/js/share.js
+++ b/public/js/share.js
@@ -1,0 +1,36 @@
+export function initShare(outEl, setResultEnabled){
+  const btnShare = document.getElementById('share');
+  const API = '';
+
+  btnShare?.addEventListener('click', async () => {
+    try{
+      const res = await fetch(`${API}/share`, {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ data: outEl.textContent })
+      });
+      if(!res.ok) throw new Error('share failed');
+      const { id } = await res.json();
+      const url = `${location.origin}${location.pathname}#id=${id}`;
+      await navigator.clipboard.writeText(url);
+      btnShare.classList.add('show-badge');
+      setTimeout(()=> btnShare.classList.remove('show-badge'), 1200);
+    }catch(e){
+      console.error(e);
+    }
+  });
+
+  window.addEventListener('DOMContentLoaded', async ()=>{
+    const m = location.hash.match(/#id=([\w-]+)/);
+    if(!m) return;
+    try{
+      const res = await fetch(`${API}/share/${m[1]}`);
+      if(!res.ok) return;
+      const { data } = await res.json();
+      outEl.textContent = data || '';
+      setResultEnabled(!!data?.trim?.());
+    }catch(e){
+      console.error(e);
+    }
+  });
+}

--- a/public/js/theme.js
+++ b/public/js/theme.js
@@ -1,0 +1,43 @@
+export function initTheme(){
+  const root = document.documentElement;
+  const systemQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  const btnSystem = document.getElementById('themeSystem');
+  const btnDark = document.getElementById('themeDark');
+  const btnLight = document.getElementById('themeLight');
+
+  function apply(theme){
+    localStorage.setItem('theme', theme);
+    root.dataset.theme = theme;
+    if(theme === 'system'){
+      setDark(systemQuery.matches);
+    }else if(theme === 'dark'){
+      setDark(true);
+    }else{
+      setDark(false);
+    }
+    updatePressed(theme);
+  }
+
+  function setDark(on){
+    root.classList.toggle('dark', !!on);
+  }
+
+  function updatePressed(theme){
+    [btnSystem, btnDark, btnLight].forEach(b=> b && b.setAttribute('aria-pressed','false'));
+    const map = {system:btnSystem, dark:btnDark, light:btnLight};
+    if(map[theme]) map[theme].setAttribute('aria-pressed','true');
+  }
+
+  systemQuery.addEventListener('change', e => {
+    if(localStorage.getItem('theme') === 'system'){
+      setDark(e.matches);
+    }
+  });
+
+  btnSystem?.addEventListener('click', ()=>apply('system'));
+  btnDark?.addEventListener('click', ()=>apply('dark'));
+  btnLight?.addEventListener('click', ()=>apply('light'));
+
+  const saved = localStorage.getItem('theme') || 'system';
+  apply(saved);
+}


### PR DESCRIPTION
## Summary
- split monolithic app.js into ES modules for main logic, theme control, sharing, and textarea autoresize
- load new module entry point in index.html

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aff96943ec8326aec4bff482363e0e