### PR TITLE
Expire shared links after 24h

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ make down
 
 - ✅ Format and transform **JSON** with jq  
 - ✅ Format and transform **YAML** with js-yaml + jq  
-- ✅ Copy, download, or upload data files  
-- ✅ Modern, responsive UI  
+- ✅ Copy, download, or upload data files
+- ✅ Share formatted results via URL (links expire after 24 h)
+- ✅ Modern, responsive UI
 - 🔒 Your data is processed inside a local container  
 
 ---

--- a/backend/share.endpoints.js
+++ b/backend/share.endpoints.js
@@ -7,10 +7,19 @@ const { randomBytes } = require('crypto');
 
 module.exports = function initShareEndpoints(app){
   const shares = new Map(); // id -> { data, createdAt }
+  const TTL_MS = 1000 * 60 * 60 * 24; // expire shares after 24h
 
   function genId(n = 10){
     return randomBytes(n).toString('base64').replace(/[+/=]/g, '').slice(0, n);
   }
+
+  // Periodically clean up expired shares
+  setInterval(() => {
+    const now = Date.now();
+    for (const [id, { createdAt }] of shares.entries()) {
+      if (now - createdAt >= TTL_MS) shares.delete(id);
+    }
+  }, TTL_MS);
 
   app.post('/share', (req, res) => {
     const data = typeof req.body?.data === 'string' ? req.body.data : '';
@@ -23,6 +32,10 @@ module.exports = function initShareEndpoints(app){
   app.get('/share/:id', (req, res) => {
     const rec = shares.get(req.params.id);
     if (!rec) return res.status(404).json({ error: 'not found' });
+    if (Date.now() - rec.createdAt >= TTL_MS) {
+      shares.delete(req.params.id);
+      return res.status(404).json({ error: 'not found' });
+    }
     res.json({ data: rec.data });
   });
 };


### PR DESCRIPTION
## Summary
- add TTL constant and cleanup for in-memory shares
- reject requests for expired shares
- document share link expiration in README

## Testing
- `node --check backend/share.endpoints.js`
- `cd backend && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b47f62ca608326a1cde70a0b5a3d34