### PR TITLE
Preserve uploaded filename for download

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -116,7 +116,7 @@ fileInput?.addEventListener("change", async (e) => {
   out.textContent = "";
   fileNameEl.textContent = f ? f.name : "No file selected";
   originalRaw = "";
-  originalName = "";
+  originalName = f ? f.name : "";
   setResultEnabled(false);
   if (!f) return;
 
@@ -273,10 +273,7 @@ downloadBtn.onclick = () => {
 
   // Nombre base
   let base = "result";
-  if (fileInput.files.length > 0) {
-    const original = fileInput.files[0].name;
-    base = original.replace(/\.[^/.]+$/, "") || "result";
-  } else if (originalName) {
+  if (originalName) {
     base = originalName.replace(/\.[^/.]+$/, "") || "result";
   }
 


### PR DESCRIPTION
## Summary
- store the uploaded file's name when selecting a file
- use stored original name when building the download filename

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b489aa4ec08326af5f9c30792120d6