### PR TITLE
feat: limit shared data size

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ make down
 - ✅ Format and transform **JSON** with jq  
 - ✅ Format and transform **YAML** with js-yaml + jq  
 - ✅ Copy, download, or upload data files
-- ✅ Share formatted results via URL (links expire after 24 h)
+- ✅ Share formatted results via URL (links expire after 24 h; max 300 KB)
 - ✅ Modern, responsive UI
 - 🔒 Your data is processed inside a local container  
 

--- a/backend/share.endpoints.js
+++ b/backend/share.endpoints.js
@@ -8,6 +8,7 @@ const { randomBytes } = require('crypto');
 module.exports = function initShareEndpoints(app){
   const shares = new Map(); // id -> { data, createdAt }
   const TTL_MS = 1000 * 60 * 60 * 24; // expire shares after 24h
+  const MAX_LEN = 300 * 1024; // 300 KB
 
   function genId(n = 10){
     return randomBytes(n).toString('base64').replace(/[+/=]/g, '').slice(0, n);
@@ -24,6 +25,9 @@ module.exports = function initShareEndpoints(app){
   app.post('/share', (req, res) => {
     const data = typeof req.body?.data === 'string' ? req.body.data : '';
     if (!data) return res.status(400).json({ error: 'data required' });
+    if (data.length > MAX_LEN) {
+      return res.status(400).json({ error: 'data too large (max 300KB)' });
+    }
     const id = genId(10);
     shares.set(id, { data, createdAt: Date.now() });
     res.json({ id });


### PR DESCRIPTION
## Summary
- limit `/share` data size to 300KB and return 400 if exceeded
- document 300KB limit for shared links

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b489d48b188326ad4f22d72aee0f07