### PR TITLE
Improve backend config and persistent share storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@
 
 # Node
 node_modules/
+
+# Environment variables
+*.env
+
+# Share data persistence file
+backend/shares.json

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
 # Makefile at the root of data-fmt
 
-# build from scratch (ignore cache)
+# build image using cache
 build:
-	docker build --no-cache -t data-fmt -f ops/Dockerfile .
+        docker build -t data-fmt -f ops/Dockerfile .
 
-# start containers without building (uses prebuilt image)
+# rebuild from scratch (ignore cache)
+rebuild:
+        docker build --no-cache -t data-fmt -f ops/Dockerfile .
+
+# start containers using existing image
 up:
-	docker build --no-cache -t data-fmt -f ops/Dockerfile .
-	docker compose -f ops/docker-compose.yml up -d
+        docker compose -f ops/docker-compose.yml up -d
 
 # stop and remove containers
 down:

--- a/README.md
+++ b/README.md
@@ -32,10 +32,20 @@ Everything runs inside **Docker**, so you don’t need to install Node or jq on 
 ## How to run
 
 Use the `Makefile` at the root of the project.
+Before running the containers, copy the example environment file:
 
-### Clean build
+```bash
+cp backend/.env.example backend/.env
+```
+
+### Build image
 ```bash
 make build
+```
+
+### Rebuild from scratch
+```bash
+make rebuild
 ```
 
 ### Start using an already built image
@@ -74,7 +84,7 @@ It currently verifies:
 - ✅ Format and transform **JSON** with jq  
 - ✅ Format and transform **YAML** with js-yaml + jq  
 - ✅ Copy, download, or upload data files
-- ✅ Share formatted results via URL (links expire after 24 h; max 300 KB)
+- ✅ Share formatted results via URL (persisted on disk; TTL and size configurable, defaults 24 h/300 KB)
 - ✅ Modern, responsive UI
 - 🔒 Your data is processed inside a local container  
 

--- a/backend/.env
+++ b/backend/.env
@@ -1,9 +1,0 @@
-# .env file for data-fmt
-# ----------------------
-# This file defines environment variables used ONLY by the Node.js application.
-# Docker Compose will not read this file.
-#
-# PORT = the port on which the Express server will listen.
-# Default is 8080 if not set.
-
-PORT=8080

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,14 @@
+# Example .env file for data-fmt
+# ------------------------------
+# Copy this file to `.env` and adjust the values as needed.
+# These variables are read by the Node.js application. Docker Compose does not
+# automatically consume this file.
+
+# PORT = the port on which the Express server listens (default 8080)
+PORT=8080
+
+# SHARE_TTL_MS = time-to-live for shared snippets in milliseconds (default 24h)
+SHARE_TTL_MS=86400000
+
+# SHARE_MAX_LEN = maximum allowed size for shared data in bytes (default 300KB)
+SHARE_MAX_LEN=307200

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,9 +13,6 @@
         "express": "^4.19.2",
         "js-yaml": "^4.1.0",
         "multer": "^1.4.5-lts.1"
-      },
-      "devDependencies": {
-        "jest": "^29.7.0"
       }
     },
     "node_modules/accepts": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,8 +13,5 @@
     "express": "^4.19.2",
     "js-yaml": "^4.1.0",
     "multer": "^1.4.5-lts.1"
-  },
-  "devDependencies": {
-    "jest": "^29.7.0"
   }
 }

--- a/backend/share.endpoints.js
+++ b/backend/share.endpoints.js
@@ -1,14 +1,30 @@
-// Share endpoints (in-memory). Import and call with your Express app instance.
+// Share endpoints with simple file persistence. Import and call with your Express app instance.
 // Usage in server.js:
 //   const shareRoutes = require('./share.endpoints');
 //   shareRoutes(app);
 
 const { randomBytes } = require('crypto');
+const fs = require('fs');
+const path = require('path');
 
 module.exports = function initShareEndpoints(app){
-  const shares = new Map(); // id -> { data, createdAt }
-  const TTL_MS = 1000 * 60 * 60 * 24; // expire shares after 24h
-  const MAX_LEN = 300 * 1024; // 300 KB
+  const DATA_FILE = path.join(__dirname, 'shares.json');
+  let shares = new Map(); // id -> { data, createdAt }
+
+  try {
+    const raw = fs.readFileSync(DATA_FILE, 'utf8');
+    const obj = JSON.parse(raw);
+    shares = new Map(Object.entries(obj));
+  } catch {
+    shares = new Map();
+  }
+
+  const TTL_MS = Number(process.env.SHARE_TTL_MS) || 1000 * 60 * 60 * 24; // default 24h
+  const MAX_LEN = Number(process.env.SHARE_MAX_LEN) || 300 * 1024; // default 300 KB
+
+  function persist(){
+    fs.writeFileSync(DATA_FILE, JSON.stringify(Object.fromEntries(shares)), 'utf8');
+  }
 
   function genId(n = 10){
     return randomBytes(n).toString('base64').replace(/[+/=]/g, '').slice(0, n);
@@ -17,19 +33,25 @@ module.exports = function initShareEndpoints(app){
   // Periodically clean up expired shares
   setInterval(() => {
     const now = Date.now();
+    let changed = false;
     for (const [id, { createdAt }] of shares.entries()) {
-      if (now - createdAt >= TTL_MS) shares.delete(id);
+      if (now - createdAt >= TTL_MS) {
+        shares.delete(id);
+        changed = true;
+      }
     }
+    if (changed) persist();
   }, TTL_MS);
 
   app.post('/share', (req, res) => {
     const data = typeof req.body?.data === 'string' ? req.body.data : '';
     if (!data) return res.status(400).json({ error: 'data required' });
     if (data.length > MAX_LEN) {
-      return res.status(400).json({ error: 'data too large (max 300KB)' });
+      return res.status(400).json({ error: `data too large (max ${Math.floor(MAX_LEN/1024)}KB)` });
     }
     const id = genId(10);
     shares.set(id, { data, createdAt: Date.now() });
+    persist();
     res.json({ id });
   });
 
@@ -38,8 +60,22 @@ module.exports = function initShareEndpoints(app){
     if (!rec) return res.status(404).json({ error: 'not found' });
     if (Date.now() - rec.createdAt >= TTL_MS) {
       shares.delete(req.params.id);
+      persist();
       return res.status(404).json({ error: 'not found' });
     }
     res.json({ data: rec.data });
+  });
+
+  // Ensure expired entries from previous runs are cleared on startup
+  setImmediate(() => {
+    const now = Date.now();
+    let changed = false;
+    for (const [id, { createdAt }] of shares.entries()) {
+      if (now - createdAt >= TTL_MS) {
+        shares.delete(id);
+        changed = true;
+      }
+    }
+    if (changed) persist();
   });
 };


### PR DESCRIPTION
## Summary
- remove unused Jest dependency and provide `.env.example`
- refine Makefile with separate build/rebuild and ignore `.env`
- persist share endpoints to disk with TTL and size configurable via env vars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4a4899ee08326bbe20f67387ea3ec